### PR TITLE
マイページのアウトプット欄のレイアウト崩れ・ページネーション修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @outputs = @user.outputs.page(params[:page]).per(10)
+    @outputs = @user.outputs.page(params[:page]).per(6)
     @following_users = @user.following
     @follower_users = @user.followers
   end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -117,28 +117,25 @@
           </h3>
           <div class="row g-4">
             <% @outputs.each do |output| %>
-              <div class="col-md-4">
-                <div class="output-card h-80">
-                  <%= link_to output_path(output), class:  do %>
-                    </div>
-                    <div class="output-info p-3">
-                      <h5 class="book-name text-dark mb-2"><%= output.book_name %></h5>
-                      <h6 class="category-name text-dark mb-2"><%= output.category.name %></h6>
-                      <div class="output-meta">
-                        <small class="text-muted">
-                          <i class="far fa-calendar-alt"></i>
-                          <%= output.created_at.strftime("%Y/%m/%d") %>
-                        </small>
-                      </div>
-                    </div>
-                  <% end %>
-                </div>
-              </div>
-            <% end %>
-          </div>
-          <div class="pagination-container mt-5">
+              <div class="col-md-4 d-flex">
+                <%= link_to output_path(output), class: "output-card card w-100 text-decoration-none text-dark shadow-sm" do %>
+                 <div class="output-info p-3">
+                   <h5 class="book-name mb-2"><%= output.book_name %></h5>
+                   <h6 class="category-name mb-2"><%= output.category.name %></h6>
+                   <div class="output-meta">
+                     <small class="text-muted">
+                     <i class="far fa-calendar-alt"></i>
+                     <%= output.created_at.strftime("%Y/%m/%d") %>
+                     </small>
+                   </div>
+                 </div>
+               <% end %>
+             </div>
+           <% end %>
+         </div>
+         <div class="pagination-container mt-5">
             <%= paginate @outputs %>
-          </div>
+         </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
マイページのアウトプットが3件を超えるとレイアウトが崩れるため、viewのコードを修正しました。
あわせて、マイページのアウトプット欄のページネーションも10件から6件に修正しました